### PR TITLE
feat: bump pubsub-http-handler to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@slack/web-api": "^6.7.2",
     "axios": "^0.27.2",
     "fastify": "^4.13.0",
-    "pubsub-http-handler": "^4.1.0",
+    "pubsub-http-handler": "^5.0.0",
     "runtypes": "^6.5.1",
     "ts-invariant": "^0.10.3"
   }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -4,7 +4,9 @@ import { SlackApiMethod } from './methods/api';
 import { SlackWebhookMethod } from './methods/webhook';
 import { LogEntry, SlackConfig, SlackMethod } from './types';
 
-export function makeHandler(config: SlackConfig): PubSubHandler<LogEntry> {
+export function makeHandler<Context = null, Logger = null>(
+  config: SlackConfig,
+): PubSubHandler<LogEntry, Context, Logger> {
   if (config.type !== 'api' && config.type !== 'webhook') {
     throw new Error('Slack config type was neither set to `api` nor `webhook`');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,10 +363,12 @@
   dependencies:
     fast-json-stringify "^5.0.0"
 
-"@fastify/type-provider-typebox@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@fastify/type-provider-typebox/-/type-provider-typebox-1.0.0.tgz#cbf550cfba29cec8ac3a06c672caddfb7e61dd03"
-  integrity sha512-PPg4mKXyXfKRM/KTa2HY04Xta2+fcVmHd6XjmzCdws32dutG0raExeQWhhzVftQMuYP62f6VGXRBOQBnpCBJ7w==
+"@fastify/type-provider-typebox@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/type-provider-typebox/-/type-provider-typebox-3.1.0.tgz#55e4e2d981c55c06d1d06638399aa37a2159162c"
+  integrity sha512-gR1ZYaFbnPd5U24OblcvFJsqcwb2U9oXnmeSEL3FQakgoQ2J5lPluUMU/Rmq9LOy6DMUILuyj+uwXTYh7PNqpQ==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -648,15 +650,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sinclair/typebox@^0.23.5":
-  version "0.23.5"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
-  integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
-
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
+
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
 "@sinonjs/commons@^2.0.0":
   version "2.0.0"
@@ -1934,6 +1936,11 @@ fast-uri@^2.0.0, fast-uri@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.2.0.tgz#519a0f849bef714aad10e9753d69d8f758f7445a"
   integrity sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==
+
+fastify-plugin@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.5.0.tgz#8b853923a0bba6ab6921bb8f35b81224e6988d91"
+  integrity sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg==
 
 fastify@^4.0.1, fastify@^4.13.0:
   version "4.13.0"
@@ -3362,6 +3369,13 @@ pino-abstract-transport@v1.0.0:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
 
+pino-cloud-logging@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pino-cloud-logging/-/pino-cloud-logging-1.0.6.tgz#6fb4acf4ebbc372b5528f1625cae8274ad737fa9"
+  integrity sha512-G0UbEJo4J86LcGeqMl5sg66133DryX0DT1zbyHXmYJEwkFAEeOXT+dVbeJ0Xo8lS5+d8XHlZn4U9Z5rp7hF30w==
+  dependencies:
+    pino "^8.0.0"
+
 pino-std-serializers@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz#307490fd426eefc95e06067e85d8558603e8e844"
@@ -3458,16 +3472,17 @@ proxy-addr@^2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-pubsub-http-handler@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/pubsub-http-handler/-/pubsub-http-handler-4.1.0.tgz#4a275f7f4c0f2c43290121c82f2e4674e28e2960"
-  integrity sha512-Ju8SyFiAk2xHegUUT1mwR/3CAVW4BOkHBXaHqXlWGDTpv/carpIBAir/83WhZIvPSugbnwoAA7ivSMfHY1LDNg==
+pubsub-http-handler@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pubsub-http-handler/-/pubsub-http-handler-5.0.0.tgz#b9b4598b7cee7dcd28880439ca02ed69a3312f8f"
+  integrity sha512-ylo1DRgRIHG3VuVbWrw6c2Y9vz7SOhhsZY/8ef6mZod23LDZlBMeU2untzW+DnG98SjWLSEaZyZtlBUuZlxwGQ==
   dependencies:
-    "@fastify/type-provider-typebox" "^1.0.0"
-    "@sinclair/typebox" "^0.23.5"
+    "@fastify/type-provider-typebox" "^3.1.0"
     "@types/express" "^4.17.13"
     fastify "^4.0.1"
+    fastify-plugin "^4.2.0"
     pino "^8.0.0"
+    pino-cloud-logging "^1.0.3"
 
 punycode@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
BREAKING CHANGE: Drops support for `makePubSubServer`. See https://github.com/simenandre/pubsub-http-handler/pull/255

closes #194
